### PR TITLE
[1572. Matrix Diagonal Sum]

### DIFF
--- a/1572-MatrixDiagonalSum/CPP/main.cpp
+++ b/1572-MatrixDiagonalSum/CPP/main.cpp
@@ -1,0 +1,42 @@
+/*
+1572. Matrix Diagonal Sum
+
+Given a square matrix mat, return the sum of the matrix diagonals.
+
+Only include the sum of all the elements on the primary diagonal and all the elements on the secondary diagonal that are not part of the primary diagonal.
+
+Example 1:
+
+Input: mat = [[1,2,3],
+[4,5,6],
+[7,8,9]]
+Output: 25
+Explanation: Diagonals sum: 1 + 5 + 9 + 3 + 7 = 25
+Notice that element mat[1][1] = 5 is counted only once.
+Example 2:
+
+Input: mat = [[1,1,1,1],
+[1,1,1,1],
+[1,1,1,1],
+[1,1,1,1]]
+Output: 8
+Example 3:
+
+Input: mat = [[5]]
+Output: 5
+*/
+
+#include<iostream>
+#include<vector>
+using namespace std;
+int diagonalSum(vector<vector<int>>& mat) {
+   int n = mat.size(), res = 0;
+
+   for( int i = 0; i<n; i++){
+        res += mat[i][i];
+        if( i != n-i-1) {
+            res += mat[i][n-i-1];
+        }
+   }
+   return res;
+}

--- a/1572-MatrixDiagonalSum/Go/main.go
+++ b/1572-MatrixDiagonalSum/Go/main.go
@@ -1,0 +1,41 @@
+/*
+1572. Matrix Diagonal Sum
+
+Given a square matrix mat, return the sum of the matrix diagonals.
+
+Only include the sum of all the elements on the primary diagonal and all the elements on the secondary diagonal that are not part of the primary diagonal.
+
+Example 1:
+
+Input: mat = [[1,2,3],
+[4,5,6],
+[7,8,9]]
+Output: 25
+Explanation: Diagonals sum: 1 + 5 + 9 + 3 + 7 = 25
+Notice that element mat[1][1] = 5 is counted only once.
+Example 2:
+
+Input: mat = [[1,1,1,1],
+[1,1,1,1],
+[1,1,1,1],
+[1,1,1,1]]
+Output: 8
+Example 3:
+
+Input: mat = [[5]]
+Output: 5
+*/
+package main
+
+func diagonalSum(mat [][]int) int {
+	n, res := len(mat), 0
+
+	for i := 0; i < n; i++ {
+		res += mat[i][i]
+
+		if i != n-i-1 {
+			res += mat[i][n-i-1]
+		}
+	}
+	return res
+}

--- a/README.md
+++ b/README.md
@@ -15,3 +15,5 @@
 - [649. Dota2 Senate](https://leetcode.com/problems/dota2-senate/description/) Go/Golang and C++ solutions implemented
 
 - [1456. Maximum Number of Vowels in a Substring of Given Length](https://leetcode.com/problems/maximum-number-of-vowels-in-a-substring-of-given-length/description/) Go/Golang and C++ solutions implemented
+
+- [1572. Matrix Diagonal Sum](https://leetcode.com/problems/matrix-diagonal-sum/description/) Go/Golang and C++ solutions implemented


### PR DESCRIPTION
C++ and Go solution for the below problem
[1572. Matrix Diagonal Sum](https://leetcode.com/problems/matrix-diagonal-sum/description/)

Given a square matrix mat, return the sum of the matrix diagonals.

Only include the sum of all the elements on the primary diagonal and all the elements on the secondary diagonal that are not part of the primary diagonal.


Example 1:


Input: mat = [[1,2,3],
              [4,5,6],
              [7,8,9]]
Output: 25
Explanation: Diagonals sum: 1 + 5 + 9 + 3 + 7 = 25
Notice that element mat[1][1] = 5 is counted only once.
Example 2:

Input: mat = [[1,1,1,1],
              [1,1,1,1],
              [1,1,1,1],
              [1,1,1,1]]
Output: 8
Example 3:

Input: mat = [[5]]
Output: 5
 

Constraints:

n == mat.length == mat[i].length
1 <= n <= 100
1 <= mat[i][j] <= 100